### PR TITLE
Add InfluxDB and Cassandra to infrastructure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This chart will do the following:
 * Deploy SiteWhere Microservices. The table bellow describes the microservices deployed base on the profile selected.
 
   | Microservice             | Defaul Profile | Minimal Profile |
-  | ------------------------ | -------------- | --------------- |
+  | :----------------------- | :------------- | :-------------- |
   | Asset Management         | ✓              | ✓               |
   | Device Management        | ✓              | ✓               |
   | Event Management         | ✓              | ✓               |
@@ -49,7 +49,7 @@ The following tables list the configurable parameters of the SiteWhere chart and
 ### Microservice Configration
 
 | Parameter                        | Description                                          | Default                          |
-| ---------------------------------| -----------------------------------------------------|----------------------------------|
+| :--------------------------------| :--------------------------------------------------- | :------------------------------- |
 | services.profile                 | SiteWhere profile `default` or `minimal`             | `default`                        |
 | services.debug                   | Use debug images                                     | `false`                          |
 | services.image.registry          | Image registry for microservices container images    | docker.io                        |
@@ -62,7 +62,7 @@ The following tables list the configurable parameters of the SiteWhere chart and
 Each _microservice_ has the following configuration:
 
 | Parameter                                            | Description                                     | Default           |
-| -----------------------------------------------------| ------------------------------------------------|-------------------|
+| :----------------------------------------------------| :---------------------------------------------- | :---------------- |
 | services._microservice_.enabled                      | `true` if microservice is enabled               | `true`            |
 | services._microservice_.image                        | Microservice container images                   | _microservice_    |
 | services._microservice_.replicaCount                 | Microservice Replica Count                      | 1                 |
@@ -73,7 +73,7 @@ Each _microservice_ has the following configuration:
 Debug image ports
 
 | Microservice             | JDWP Port      | JMX Port        |
-| ------------------------ | -------------- | --------------- |
+| :----------------------- | :------------- | :-------------- |
 | Instance Managemwnt      | 8001           | 1101            |
 | User Management          | 8002           | 1102            |
 | Tenant Management        | 8003           | 1103            |
@@ -99,7 +99,8 @@ Debug image ports
 #### General Infrastructure Configuration
 
 | Parameter                        | Description                                          | Default                          |
-| ---------------------------------| -----------------------------------------------------|----------------------------------|
+| :------------------------------- | :--------------------------------------------------- | :------------------------------- |
+| infra.profile                    | Available values: `mongodb` `cassandra` `influxdb`   | `mongodb`                        |
 | infra.image.registry             | Image registry for infrastructure container images   | docker.io                        |
 | infra.image.pullPolicy           | Image pull policy for infrastructure images          | IfNotPresent                     |
 | infra.image.imagePullSecrets     | Image pull secrets for infrastructure images         | `nil`                            |
@@ -107,14 +108,14 @@ Debug image ports
 #### Infrastructure Persistence Configuration
 
 | Parameter                        | Description                                          | Default                          |
-| ---------------------------------| -----------------------------------------------------|----------------------------------|
+| :------------------------------- | :--------------------------------------------------- | :------------------------------- |
 | persistence.storageClass         | Storage Class used in Persistence Volume Claims      | rook-ceph-block                  |
 | persistence.storage              | Storage Size of Persistence Volume Claim             | 10Gi                             |
 
 #### Zookeeper Configration
 
 | Parameter                        | Description                                          | Default                          |
-| ---------------------------------| -----------------------------------------------------|----------------------------------|
+| :------------------------------- | :--------------------------------------------------- | :------------------------------- |
 | infra.zookeeper.image            | Zookeeper container image                            | wurstmeister/zookeeper           |
 | infra.zookeeper.replicaCount     | Zookeeper Replica Count                              | 1                                |
 | infra.zookeeper.service.type     | Zookeeper Service Type                               | ClusterIP                        |
@@ -126,37 +127,58 @@ Debug image ports
 
 #### Kafka Configuration
 
-| Parameter                             | Description                                          | Default                          |
-| --------------------------------------| -----------------------------------------------------|----------------------------------|
-| infra.kafka.image                     | Apache Kafka container image                         | wurstmeister/kafka:1.0.0         |
-| infra.kafka.replicaCount              | Apache Kafka Replica Count                           | 1                                |
-| infra.kafka.service.type              | Apache Kafka Service Type                            | ClusterIP                        |
-| infra.kafka.service.inside.port       | Apache Kafka Inside Service Port                     | 9092                             |
-| infra.kafka.service.outside.port      | Apache Kafka Outside Service Port                    | 9094                             |
+| Parameter                        | Description                                          | Default                          |
+| :------------------------------- | :--------------------------------------------------- | :------------------------------- |
+| infra.kafka.image                | Apache Kafka container image                         | wurstmeister/kafka:1.0.0         |
+| infra.kafka.replicaCount         | Apache Kafka Replica Count                           | 1                                |
+| infra.kafka.service.type         | Apache Kafka Service Type                            | ClusterIP                        |
+| infra.kafka.service.inside.port  | Apache Kafka Inside Service Port                     | 9092                             |
+| infra.kafka.service.outside.port | Apache Kafka Outside Service Port                    | 9094                             |
 
 #### Jaeger Configuration
 
-| Parameter                             | Description                                    | Default                          |
-| --------------------------------------| -----------------------------------------------|----------------------------------|
-| infra.jaeger.image                    | Jaeger container image                         | jaegertracing/all-in-one         |
-| infra.jaeger.replicaCount             | Jaeger Replica Count                           | 1                                |
-| infra.jaeger.service.type             | Jaeger Service Type                            | ClusterIP                        |
-| infra.jaeger.service.ports.zipkin     | Jaeger Zipkin Service Port                     | 9411                             |
-| infra.jaeger.service.ports.ui         | Jaeger UI Service Port                         | 16686                            |
+| Parameter                         | Description                                    | Default                          |
+| :-------------------------------- | :--------------------------------------------- | :------------------------------- |
+| infra.jaeger.image                | Jaeger container image                         | jaegertracing/all-in-one         |
+| infra.jaeger.replicaCount         | Jaeger Replica Count                           | 1                                |
+| infra.jaeger.service.type         | Jaeger Service Type                            | ClusterIP                        |
+| infra.jaeger.service.ports.zipkin | Jaeger Zipkin Service Port                     | 9411                             |
+| infra.jaeger.service.ports.ui     | Jaeger UI Service Port                         | 16686                            |
 
 #### MongoDB Configuration
 
-| Parameter                             | Description                                     | Default                          |
-| --------------------------------------| ------------------------------------------------|----------------------------------|
-| infra.mongodb.image                   | MongoDB container image                         | mongo:3                          |
-| infra.mongodb.replicaCount            | MongoDB Replica Count                           | 1                                |
-| infra.mongodb.service.type            | MongoDB Service Type                            | ClusterIP                        |
-| infra.mongodb.service.port            | MongoDB Service Port                            | 27017                            |
+| Parameter                        | Description                                     | Default                          |
+| :------------------------------- | :---------------------------------------------- | :------------------------------- |
+| infra.mongodb.image              | MongoDB container image                         | mongo:3                          |
+| infra.mongodb.enabled            | Enable MongoDB                                  | `true`                           |
+| infra.mongodb.replicaCount       | MongoDB Replica Count                           | 1                                |
+| infra.mongodb.service.type       | MongoDB Service Type                            | ClusterIP                        |
+| infra.mongodb.service.port       | MongoDB Service Port                            | 27017                            |
+
+#### Cassandra Configuration
+
+| Parameter                        | Description                                     | Default                          |
+| :------------------------------- | :---------------------------------------------- | :------------------------------- |
+| infra.cassandra.image            | Cassandra container image                       | cassandra:3.11                   |
+| infra.cassandra.enabled          | Enable Cassandra                                | `false`                          |
+| infra.cassandra.replicaCount     | Cassandra Replica Count                         | 1                                |
+| infra.cassandra.service.type     | Cassandra Service Type                          | ClusterIP                        |
+| infra.cassandra.service.port     | Cassandra Service Port                          | 9042                             |
+
+#### InfluxDB Configuration
+
+| Parameter                        | Description                                     | Default                          |
+| :------------------------------- | :---------------------------------------------- | :------------------------------- |
+| infra.influxdb.image             | InfluxDB container image                        | influxdb:1.3-alpine              |
+| infra.influxdb.enabled           | Enable InfluxDB                                 | `false`                          |
+| infra.influxdb.replicaCount      | InfluxDB Replica Count                          | 1                                |
+| infra.influxdb.service.type      | InfluxDB Service Type                           | ClusterIP                        |
+| infra.influxdb.service.port      | InfluxDB Service Port                           | 8086                             |
 
 #### Eclipse Mosquitto Configuration
 
 | Parameter                             | Description                                     | Default                          |
-| --------------------------------------| ------------------------------------------------|----------------------------------|
+| :------------------------------------ | :---------------------------------------------- | :------------------------------- |
 | infra.mosquitto.image                 | Eclipse Mosquitto container image               | eclipse-mosquitto:1.4.12         |
 | infra.mosquitto.replicaCount          | Eclipse Mosquitto Replica Count                 | 1                                |
 | infra.mosquitto.service.type          | Eclipse Mosquitto Service Type                  | LoadBalancer                     |

--- a/charts/sitewhere/templates/Cassandra.yaml
+++ b/charts/sitewhere/templates/Cassandra.yaml
@@ -1,46 +1,46 @@
-{{- if include "infra.mongodb.enabled" . }}
+{{- if include "infra.cassandra.enabled" . }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "sitewhere.fullname" . }}-mongodb
+  name: {{ include "sitewhere.fullname" . }}-cassandra
   labels:
     app.kubernetes.io/name: {{ include "sitewhere.name" . }}
     helm.sh/chart: {{ include "sitewhere.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.infra.mongodb.replicaCount }}
+  replicas: {{ .Values.infra.cassandra.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "sitewhere.name" . }}-mongodb
+      app.kubernetes.io/name: {{ include "sitewhere.name" . }}-cassandra
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "sitewhere.name" . }}-mongodb
+        app.kubernetes.io/name: {{ include "sitewhere.name" . }}-cassandra
         app.kubernetes.io/instance: {{ .Release.Name }}
         sitewhere.io/role: "infrastructure"
-        sitewhere.io/name: "mongodb"
+        sitewhere.io/name: "cassandra"
     spec:
       containers:
-        - name: {{ .Chart.Name }}-mongodb
-          image: "{{ .Values.infra.image.registry }}/{{ .Values.infra.mongodb.image }}"
+        - name: {{ .Chart.Name }}-cassandra
+          image: "{{ .Values.infra.image.registry }}/{{ .Values.infra.cassandra.image }}"
           imagePullPolicy: {{ .Values.infra.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.infra.mongodb.service.port }}
-              name: mongodb-port
+            - containerPort: {{ .Values.infra.cassandra.service.port }}
+              name: cassandra-port
               protocol: TCP
           volumeMounts:
-            - name: {{ include "sitewhere.fullname" . }}-mongodb-pv
-              mountPath: /data/db
+            - name: {{ include "sitewhere.fullname" . }}-cassandra-pv
+              mountPath: /var/lib/cassandra
       volumes:
-        - name: {{ include "sitewhere.fullname" . }}-mongodb-pv
+        - name: {{ include "sitewhere.fullname" . }}-cassandra-pv
           persistentVolumeClaim:
-            claimName: {{ include "sitewhere.fullname" . }}-mongodb-pvc
+            claimName: {{ include "sitewhere.fullname" . }}-cassandra-pvc
 {{ include "sitewhere.infra.imagePullSecrets" . | indent 6 }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ include "sitewhere.fullname" . }}-mongodb-pv
+        name: {{ include "sitewhere.fullname" . }}-cassandra-pv
       spec:
         accessModes:
           - ReadWriteOnce
@@ -54,20 +54,20 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "sitewhere.fullname" . }}-mongodb-svc
+  name: {{ include "sitewhere.fullname" . }}-cassandra-svc
   labels:
     app.kubernetes.io/name: {{ include "sitewhere.name" . }}
     helm.sh/chart: {{ include "sitewhere.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  type: {{ .Values.infra.mongodb.service.type }}
+  type: {{ .Values.infra.cassandra.service.type }}
   ports:
-    - port: {{ .Values.infra.mongodb.service.port }}
-      targetPort: {{ .Values.infra.mongodb.service.port }}
+    - port: {{ .Values.infra.cassandra.service.port }}
+      targetPort: {{ .Values.infra.cassandra.service.port }}
       protocol: TCP
-      name: mongodb-port
+      name: cassandra-port
   selector:
-    app.kubernetes.io/name: {{ include "sitewhere.name" . }}-mongodb
+    app.kubernetes.io/name: {{ include "sitewhere.name" . }}-cassandra
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/sitewhere/templates/InfluxDB.yaml
+++ b/charts/sitewhere/templates/InfluxDB.yaml
@@ -1,46 +1,46 @@
-{{- if include "infra.mongodb.enabled" . }}
+{{- if include "infra.influxdb.enabled" . }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "sitewhere.fullname" . }}-mongodb
+  name: {{ include "sitewhere.fullname" . }}-influxdb
   labels:
     app.kubernetes.io/name: {{ include "sitewhere.name" . }}
     helm.sh/chart: {{ include "sitewhere.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.infra.mongodb.replicaCount }}
+  replicas: {{ .Values.infra.influxdb.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "sitewhere.name" . }}-mongodb
+      app.kubernetes.io/name: {{ include "sitewhere.name" . }}-influxdb
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "sitewhere.name" . }}-mongodb
+        app.kubernetes.io/name: {{ include "sitewhere.name" . }}-influxdb
         app.kubernetes.io/instance: {{ .Release.Name }}
         sitewhere.io/role: "infrastructure"
-        sitewhere.io/name: "mongodb"
+        sitewhere.io/name: "influxdb"
     spec:
       containers:
-        - name: {{ .Chart.Name }}-mongodb
-          image: "{{ .Values.infra.image.registry }}/{{ .Values.infra.mongodb.image }}"
+        - name: {{ .Chart.Name }}-influxdb
+          image: "{{ .Values.infra.image.registry }}/{{ .Values.infra.influxdb.image }}"
           imagePullPolicy: {{ .Values.infra.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.infra.mongodb.service.port }}
-              name: mongodb-port
+            - containerPort: {{ .Values.infra.influxdb.service.port }}
+              name: influxdb-port
               protocol: TCP
           volumeMounts:
-            - name: {{ include "sitewhere.fullname" . }}-mongodb-pv
-              mountPath: /data/db
+            - name: {{ include "sitewhere.fullname" . }}-influxdb-pv
+              mountPath: /var/lib/influxdb
       volumes:
-        - name: {{ include "sitewhere.fullname" . }}-mongodb-pv
+        - name: {{ include "sitewhere.fullname" . }}-influxdb-pv
           persistentVolumeClaim:
-            claimName: {{ include "sitewhere.fullname" . }}-mongodb-pvc
+            claimName: {{ include "sitewhere.fullname" . }}-influxdb-pvc
 {{ include "sitewhere.infra.imagePullSecrets" . | indent 6 }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ include "sitewhere.fullname" . }}-mongodb-pv
+        name: {{ include "sitewhere.fullname" . }}-influxdb-pv
       spec:
         accessModes:
           - ReadWriteOnce
@@ -54,20 +54,20 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "sitewhere.fullname" . }}-mongodb-svc
+  name: {{ include "sitewhere.fullname" . }}-influxdb-svc
   labels:
     app.kubernetes.io/name: {{ include "sitewhere.name" . }}
     helm.sh/chart: {{ include "sitewhere.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  type: {{ .Values.infra.mongodb.service.type }}
+  type: {{ .Values.infra.influxdb.service.type }}
   ports:
-    - port: {{ .Values.infra.mongodb.service.port }}
-      targetPort: {{ .Values.infra.mongodb.service.port }}
+    - port: {{ .Values.infra.influxdb.service.port }}
+      targetPort: {{ .Values.infra.influxdb.service.port }}
       protocol: TCP
-      name: mongodb-port
+      name: influxdb-port
   selector:
-    app.kubernetes.io/name: {{ include "sitewhere.name" . }}-mongodb
+    app.kubernetes.io/name: {{ include "sitewhere.name" . }}-influxdb
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/sitewhere/templates/_infraEnabled.tpl
+++ b/charts/sitewhere/templates/_infraEnabled.tpl
@@ -1,0 +1,33 @@
+{{/*
+  | Service                  | Defaul Profile | Minimal Profile |
+  | :----------------------- | :------------- | :-------------- |
+  | MongoDB                  | ✓              | ✓               |
+  | Cassandra                | ✓              | ✓               |
+  | InfuxDB                  | ✓              | ✓               |
+*/}}
+{{/*
+Returns true if MongoDB is enabled.
+*/}}
+{{- define "infra.mongodb.enabled" -}}
+{{- if (or (eq .Values.infra.profile "mongodb") (.Values.infra.mongodb.enabled)) -}}
+-
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true if Cassandra is enabled.
+*/}}
+{{- define "infra.cassandra.enabled" -}}
+{{- if (or (eq .Values.infra.profile "cassandra") (.Values.infra.cassandra.enabled)) -}}
+-
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true if InfluxDB is enabled.
+*/}}
+{{- define "infra.influxdb.enabled" -}}
+{{- if (or (eq .Values.infra.profile "influxdb") (.Values.infra.influxdb.enabled)) -}}
+-
+{{- end -}}
+{{- end -}}

--- a/charts/sitewhere/values.yaml
+++ b/charts/sitewhere/values.yaml
@@ -1,10 +1,12 @@
 # SiteWhere Infrastructure
 infra:
+  profile: mongodb
   image:
     registry: docker.io
     pullPolicy: IfNotPresent
     imagePullSecrets: "-"
   zookeeper:
+    enabled: true
     image: wurstmeister/zookeeper
     replicaCount: 1
     service:
@@ -18,6 +20,7 @@ infra:
     api:
       image: elkozmon/zoonavigator-api:latest
   kafka:
+    enabled: true
     image: wurstmeister/kafka:1.0.0
     replicaCount: 1
     service:
@@ -27,6 +30,7 @@ infra:
       outside:
         port: 9094
   jaeger:
+    enabled: true
     image: jaegertracing/all-in-one
     replicaCount: 1
     service:
@@ -35,11 +39,26 @@ infra:
         zipkin: "9411"
         ui: "16686"
   mongodb:
+    enabled: true
     image: mongo:3
     replicaCount: 1
     service:
       type: ClusterIP
       port: 27017
+  cassandra:
+    enabled: false
+    image: cassandra:3.11
+    replicaCount: 1
+    service:
+      type: ClusterIP
+      port: 9042
+  influxdb:
+    enabled: false
+    image: influxdb:1.3-alpine
+    replicaCount: 1
+    service:
+      type: ClusterIP
+      port: 8086
   mosquitto:
     enabled: true
     image: eclipse-mosquitto:1.4.12


### PR DESCRIPTION
Add the ability to deploy Cassanda and InfluxDB as part of `helm install`.
Using `--set infra.profile=cassandra` or `--set infra.cassandra.enabled=true` Cassandra can be deplyed, also `--set infra.profile=influxdb` or `--set infra.influxdb.enabled=true` can be used to deploy InfluxDB.