### PR TITLE
Use common include for liveness/readiness probes.

### DIFF
--- a/charts/sitewhere/templates/Asset-Management.yaml
+++ b/charts/sitewhere/templates/Asset-Management.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.asset_management.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.asset_management.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Batch-Operations.yaml
+++ b/charts/sitewhere/templates/Batch-Operations.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.batch_operations.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.batch_operations.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Command-Delivery.yaml
+++ b/charts/sitewhere/templates/Command-Delivery.yaml
@@ -48,15 +48,7 @@ spec:
             requests:
               memory: {{ .Values.services.command_delivery.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.command_delivery.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Device-Management.yaml
+++ b/charts/sitewhere/templates/Device-Management.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.device_management.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.device_management.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Device-Registration.yaml
+++ b/charts/sitewhere/templates/Device-Registration.yaml
@@ -48,15 +48,7 @@ spec:
             requests:
               memory: {{ .Values.services.device_registration.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.device_registration.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Device-State.yaml
+++ b/charts/sitewhere/templates/Device-State.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.device_state.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.device_state.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Event-Management.yaml
+++ b/charts/sitewhere/templates/Event-Management.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.event_management.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.event_management.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Event-Search.yaml
+++ b/charts/sitewhere/templates/Event-Search.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.event_search.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.event_search.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Event-Sources.yaml
+++ b/charts/sitewhere/templates/Event-Sources.yaml
@@ -48,15 +48,7 @@ spec:
             requests:
               memory: {{ .Values.services.event_sources.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.event_sources.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Inbound-Processing.yaml
+++ b/charts/sitewhere/templates/Inbound-Processing.yaml
@@ -48,15 +48,7 @@ spec:
             requests:
               memory: {{ .Values.services.inbound_processing.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.inbound_processing.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Instance-Management.yaml
+++ b/charts/sitewhere/templates/Instance-Management.yaml
@@ -48,15 +48,7 @@ spec:
             requests:
               memory: {{ .Values.services.instance_management.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.instance_management.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Label-Generation.yaml
+++ b/charts/sitewhere/templates/Label-Generation.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.label_generation.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.label_generation.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Outbound-Connectors.yaml
+++ b/charts/sitewhere/templates/Outbound-Connectors.yaml
@@ -48,15 +48,7 @@ spec:
             requests:
               memory: {{ .Values.services.outbound_connectors.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.outbound_connectors.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Rule-Processing.yaml
+++ b/charts/sitewhere/templates/Rule-Processing.yaml
@@ -48,15 +48,7 @@ spec:
             requests:
               memory: {{ .Values.services.rule_processing.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.rule_processing.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Schedule-Management.yaml
+++ b/charts/sitewhere/templates/Schedule-Management.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.schedule_management.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.schedule_management.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Streaming-Media.yaml
+++ b/charts/sitewhere/templates/Streaming-Media.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.streaming_media.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.streaming_media.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Tenant-Management.yaml
+++ b/charts/sitewhere/templates/Tenant-Management.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.tenant_management.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.tenant_management.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/User-Management.yaml
+++ b/charts/sitewhere/templates/User-Management.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.user_management.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.user_management.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/Web-Rest.yaml
+++ b/charts/sitewhere/templates/Web-Rest.yaml
@@ -49,15 +49,7 @@ spec:
             requests:
               memory: {{ .Values.services.web_rest.resources.requests.memory | default .Values.services.resources.requests.memory | quote }}
               cpu: {{ .Values.services.web_rest.resources.requests.cpu | default .Values.services.resources.requests.cpu | quote }}
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
-          livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
-            initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
-            periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{ include "sitewhere.microserviceProbes" . | indent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/sitewhere/templates/_microserviceProbes.tpl
+++ b/charts/sitewhere/templates/_microserviceProbes.tpl
@@ -1,0 +1,11 @@
+{{- define "sitewhere.microserviceProbes" -}}
+readinessProbe:
+  exec:
+    command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
+  initialDelaySeconds: {{ .Values.services.health.readinessProbe.initialDelay }}
+livenessProbe:
+  exec:
+    command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.services.health.port }}"]
+  initialDelaySeconds: {{ .Values.services.health.livenessProbe.initialDelay }}
+  periodSeconds: {{ .Values.services.health.livenessProbe.periodSeconds }}
+{{- end -}}

--- a/charts/sitewhere/values.yaml
+++ b/charts/sitewhere/values.yaml
@@ -59,7 +59,7 @@ services:
     sitewhere:
       level: INFO
       grpc:
-        level: INFO
+        level: DEBUG
     spring:
       boot: 
         level: INFO

--- a/charts/sitewhere/values.yaml
+++ b/charts/sitewhere/values.yaml
@@ -59,7 +59,7 @@ services:
     sitewhere:
       level: INFO
       grpc:
-        level: DEBUG
+        level: INFO
     spring:
       boot: 
         level: INFO


### PR DESCRIPTION
Allows probes to be removed from all microservices for testing.